### PR TITLE
Fix default questions value for map types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -631,7 +631,7 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "trusted-repos-policy"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "anyhow",
  "k8s-openapi",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trusted-repos-policy"
-version = "0.1.8"
+version = "0.1.9"
 authors = ["Rafael Fernández López <ereslibre@ereslibre.es>"]
 edition = "2018"
 

--- a/artifacthub-pkg.yml
+++ b/artifacthub-pkg.yml
@@ -1,21 +1,21 @@
 ---
-version: 0.1.8
+version: 0.1.9
 name: trusted-repos
 displayName: Trusted Repos
-createdAt: '2023-01-19T14:46:21+02:00'
+createdAt: '2023-03-20T20:23:44+00:00'
 description: Restrict what registries, tags and images can be used
 license: Apache-2.0
 homeURL: https://github.com/kubewarden/trusted-repos-policy
 containersImages:
 - name: policy
-  image: ghcr.io/kubewarden/policies/trusted-repos:v0.1.8
+  image: ghcr.io/kubewarden/policies/trusted-repos:v0.1.9
 keywords:
 - image
 - registry
 - tag
 links:
 - name: policy
-  url: https://github.com/kubewarden/trusted-repos-policy/releases/download/v0.1.8/policy.wasm
+  url: https://github.com/kubewarden/trusted-repos-policy/releases/download/v0.1.9/policy.wasm
 - name: source
   url: https://github.com/kubewarden/trusted-repos-policy
 provider:
@@ -47,7 +47,7 @@ annotations:
       hide_input: true
       type: string
       variable: description
-    - default: []
+    - default: {}
       description: Allow or reject images coming from a specified registry.
       group: Settings
       label: Registries
@@ -65,7 +65,7 @@ annotations:
           label: Reject
           type: array[
           variable: registries.reject
-    - default: []
+    - default: {}
       description: Reject a specified tag for all images
       group: Settings
       label: Tags
@@ -78,7 +78,7 @@ annotations:
           label: Reject
           type: array[
           variable: tags.reject
-    - default: []
+    - default: {}
       description: Accept or reject a specified image
       group: Settings
       label: Images

--- a/questions-ui.yml
+++ b/questions-ui.yml
@@ -12,7 +12,7 @@ questions:
   hide_input: true
   type: string
   variable: description
-- default: []
+- default: {}
   description: Allow or reject images coming from a specified registry.
   group: Settings
   label: Registries
@@ -30,7 +30,7 @@ questions:
       label: Reject
       type: array[
       variable: registries.reject
-- default: []
+- default: {}
   description: Reject a specified tag for all images
   group: Settings
   label: Tags
@@ -43,7 +43,7 @@ questions:
       label: Reject
       type: array[
       variable: tags.reject
-- default: []
+- default: {}
   description: Accept or reject a specified image
   group: Settings
   label: Images


### PR DESCRIPTION
## Description

Reference https://github.com/kubewarden/ui/issues/301

This fixes the `default` questions value for `map[` type, which was incorrectly set to an Array and was causing the subquestions to not add correct allow and reject values. This should help a bit with the layout on the UI, and will also bump a new version `0.1.9`.
