### PR TITLE
feat: With settings only allowing images, match any tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,3 +67,16 @@ images:
     - quay.io/coreos/etcd:v3.4.12@sha256:7ed2739c96eb16de3d7169e2a0aa4ccf3a1f44af24f2bb6cad826935a51bcb3d
     - quay.io/bitnami/redis:6.0@sha256:82dfd9ac433eacb5f89e5bf2601659bbc78893c1a9e3e830c5ef4eb489fde079
 ```
+
+- Only accept a well known set of images with any tag, reject the rest:
+
+```yaml
+images:
+  allow:
+    - nginx
+    - quay.io/coreos/etcd
+```
+
+Will allow container images like `nginx:1.21`, `nginx:latest`,
+`docker.io/library:nginx:1.21`, `quay.io/coreos/etcd:1.21`,
+`quay.io/coreos/etcd:latest`.

--- a/README.md
+++ b/README.md
@@ -12,56 +12,58 @@ The policy configuration allows to mix and match several filters:
 When both an allow list and a reject list is supported, only one can
 be provided at the same time for that specific filter.
 
-* Registries
-  * Allow list
-  * Reject list
+- Registries
 
-* Tags
-  * Reject list
+  - Allow list
+  - Reject list
 
-* Images
-  * Allow list
-  * Reject list
+- Tags
+
+  - Reject list
+
+- Images
+  - Allow list
+  - Reject list
 
 ## Examples
 
-* Only allow images coming from `registry.my-corp.com`:
+- Only allow images coming from `registry.my-corp.com`:
 
 ```yaml
 registries:
   allow:
-  - registry.my-corp.com
+    - registry.my-corp.com
 ```
 
-* Only reject one host, in this case the Docker Hub:
+- Only reject one host, in this case the Docker Hub:
 
 ```yaml
 registries:
   reject:
-  - docker.io
+    - docker.io
 ```
 
-* Reject the latest tag for all images:
+- Reject the latest tag for all images:
 
 ```yaml
 tags:
   reject:
-  - latest
+    - latest
 ```
 
-* Only reject one specific image, allow the rest:
+- Only reject one specific image, allow the rest:
 
 ```yaml
 images:
   reject:
-  - quay.io/etcd/etcd:v3.4.12
+    - quay.io/etcd/etcd:v3.4.12
 ```
 
-* Only accept a well known set of images, reject the rest:
+- Only accept a well known set of images, reject the rest:
 
 ```yaml
 images:
   allow:
-  - quay.io/coreos/etcd:v3.4.12@sha256:7ed2739c96eb16de3d7169e2a0aa4ccf3a1f44af24f2bb6cad826935a51bcb3d
-  - quay.io/bitnami/redis:6.0@sha256:82dfd9ac433eacb5f89e5bf2601659bbc78893c1a9e3e830c5ef4eb489fde079
+    - quay.io/coreos/etcd:v3.4.12@sha256:7ed2739c96eb16de3d7169e2a0aa4ccf3a1f44af24f2bb6cad826935a51bcb3d
+    - quay.io/bitnami/redis:6.0@sha256:82dfd9ac433eacb5f89e5bf2601659bbc78893c1a9e3e830c5ef4eb489fde079
 ```

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -50,6 +50,18 @@ impl Tags {
 /// the `Deserialize` trait to be able to use it in the `Settings` struct.
 #[derive(Debug, Hash, PartialEq, Eq, Clone)]
 pub struct ImageRef(oci_spec::distribution::Reference);
+impl ImageRef {
+    pub fn new(reference: oci_spec::distribution::Reference) -> Self {
+        ImageRef(reference)
+    }
+
+    pub fn repository(&self) -> &str {
+        self.0.repository()
+    }
+    pub fn registry(&self) -> &str {
+        self.0.registry()
+    }
+}
 
 impl From<Reference> for ImageRef {
     fn from(reference: Reference) -> Self {

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -38,7 +38,7 @@ impl Tags {
 
         if !invalid_tags.is_empty() {
             return Err(format!(
-                "tags {invalid_tags:?} are invalid, they must be valid OCI tags"
+                "tags {invalid_tags:?} are invalid, they must be valid OCI tags",
             ));
         }
 

--- a/src/validation.rs
+++ b/src/validation.rs
@@ -441,7 +441,7 @@ mod tests {
         let result = validate_images(&images, &settings);
         assert_eq!(
             result, expected_result,
-            "got: {result:?} instead of {expected_result:?}"
+            r#"got: {result:?} instead of {expected_result:?}"#
         );
     }
 


### PR DESCRIPTION
## Description

<!-- Please provide the link to the GitHub issue you are addressing -->
Fix https://github.com/kubewarden/trusted-repos-policy/issues/164

Settings like:

```yaml
settings:
  images:
    allow:
      - nginx
      - quay.io/coreos/etcd
```

Will now allow container images like `nginx:1.21`, `nginx:latest`,
`docker.io/library:nginx:1.21`, `quay.io/coreos/etcd:1.21`,
`quay.io/coreos/etcd:latest`.
<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->

## Test

<!-- Please provides a short description about how to test your pullrequest -->
Added several unit tests.

<!--
```shell
cp <to_package_directory>
go test
```
-->

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
