### PR TITLE
fix: Also match any tags with settings only rejecting images

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,3 +80,16 @@ images:
 Will allow container images like `nginx:1.21`, `nginx:latest`,
 `docker.io/library:nginx:1.21`, `quay.io/coreos/etcd:1.21`,
 `quay.io/coreos/etcd:latest`.
+
+- Only reject a well known set of images with any tag, allow the rest:
+
+```yaml
+images:
+  reject:
+    - nginx
+    - quay.io/coreos/etcd
+```
+
+Will reject container images like `nginx:1.21`, `nginx:latest`,
+`docker.io/library:nginx:1.21`, `quay.io/coreos/etcd:1.21`,
+`quay.io/coreos/etcd:latest`.


### PR DESCRIPTION
## Description

Settings like:

```yaml
settings:
  images:
    reject:
      - nginx
      - quay.io/coreos/etcd
```

Will now reject container images like `nginx:1.21`, `nginx:latest`, `docker.io/library:nginx:1.21`, `quay.io/coreos/etcd:1.21`, `quay.io/coreos/etcd:latest`.




<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->

## Test

<!-- Please provides a short description about how to test your pullrequest -->
To test this pull request, you can run the following commands:

<!--
```shell
cp <to_package_directory>
go test
```
-->

## Additional Information

To be released as 2.0.1

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
